### PR TITLE
2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 2.2.0
+- add "alpha-value-notation": "number", change "font-family-name-quotes" to "always-where-recommended", remove the following rules: "declaration-block-no-shorthand-property-overrides", "declaration-block-single-line-max-declarations", "media-feature-name-no-vendor-prefix", "number-max-precision", "property-no-vendor-prefix", "selector-no-vendor-prefix"
 # 2.1.0
 - update commonjs to esm
 # 2.0.0

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@ We want to work with beautiful, nicely formatted code, so with the help of style
 
 ## Installation
 ```
-npm i stylelint-config-shiwaforce --save
+npm i stylelint-config-shiwaforce --save-dev
 ```
 
 ## Usage
 If you've installed stylelint-config-shiwaforce locally within your project, just set your stylelint(`.stylelintrc.json`) config to:
 ```json
 {
-  "extends": "stylelint-config-shiwaforce"
+	"extends": "stylelint-config-shiwaforce"
 }
 ```
 
@@ -19,10 +19,10 @@ Just add ```"rules"``` key to your config, then add your additional/override rul
 For example if you would like to change ```"max-nesting-depth"``` rule from default to your own:
 ```json
 {
-  "extends": "stylelint-config-shiwaforce",
-  "rules": {
-    "max-nesting-depth": 4,
-  }
+	"extends": "stylelint-config-shiwaforce",
+	"rules": {
+		"max-nesting-depth": 4
+	}
 }
 ```
 
@@ -30,6 +30,7 @@ For example if you would like to change ```"max-nesting-depth"``` rule from defa
 ```json
 {
 	"rules": {
+		"alpha-value-notation": "number",
 		"at-rule-empty-line-before": ["always", {
 			"except": ["blockless-after-blockless", "first-nested", "blockless-after-same-name-blockless"],
 			"ignore": ["after-comment"],
@@ -39,19 +40,13 @@ For example if you would like to change ```"max-nesting-depth"``` rule from defa
 		"at-rule-no-vendor-prefix": true,
 		"block-no-empty": true,
 		"declaration-block-no-duplicate-properties": true,
-		"declaration-block-no-shorthand-property-overrides": true,
-		"declaration-block-single-line-max-declarations": 1,
 		"declaration-no-important": true,
-		"font-family-name-quotes": "always-unless-keyword",
+		"font-family-name-quotes": "always-where-recommended",
 		"length-zero-no-unit": true,
 		"max-nesting-depth": 3,
-		"media-feature-name-no-vendor-prefix": true,
 		"no-duplicate-selectors": true,
 		"no-invalid-double-slash-comments": true,
-		"number-max-precision": 6,
 		"order/properties-alphabetical-order": true,
-		"property-no-vendor-prefix": true,
-		"selector-no-vendor-prefix": true,
 		"selector-pseudo-element-colon-notation": "double",
 		"unit-allowed-list": ["px", "em", "rem", "fr", "%", "pt", "vw", "vh", "dvh", "svh", "lvh", "dvb", "svb", "lvb", "vmin", "vmax", "deg", "s", "ms"]
 	}

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 export default {
 	plugins: ['stylelint-order'],
 	rules: {
+		'alpha-value-notation': 'number',
 		'at-rule-empty-line-before': [
 			'always',
 			{
@@ -13,19 +14,13 @@ export default {
 		'at-rule-no-vendor-prefix': true,
 		'block-no-empty': true,
 		'declaration-block-no-duplicate-properties': true,
-		'declaration-block-no-shorthand-property-overrides': true,
-		'declaration-block-single-line-max-declarations': 1,
 		'declaration-no-important': true,
-		'font-family-name-quotes': 'always-unless-keyword',
+		'font-family-name-quotes': 'always-where-recommended',
 		'length-zero-no-unit': true,
 		'max-nesting-depth': 3,
-		'media-feature-name-no-vendor-prefix': true,
 		'no-duplicate-selectors': true,
 		'no-invalid-double-slash-comments': true,
-		'number-max-precision': 6,
 		'order/properties-alphabetical-order': true,
-		'property-no-vendor-prefix': true,
-		'selector-no-vendor-prefix': true,
 		'selector-pseudo-element-colon-notation': 'double',
 		'unit-allowed-list': [
 			'px',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stylelint-config-shiwaforce",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stylelint-config-shiwaforce",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "stylelint-order": "^6.0.4"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stylelint-config-shiwaforce",
-  "version": "2.2.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stylelint-config-shiwaforce",
-      "version": "2.2.0",
+      "version": "2.1.0",
       "license": "MIT",
       "dependencies": {
         "stylelint-order": "^6.0.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-shiwaforce",
-  "version": "2.2.0",
+  "version": "2.1.0",
   "type": "module",
   "description": "Shareable config for stylelint by ShiwaForce",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stylelint-config-shiwaforce",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "type": "module",
   "description": "Shareable config for stylelint by ShiwaForce",
   "keywords": [


### PR DESCRIPTION
add "alpha-value-notation": "number", change "font-family-name-quotes" to "always-where-recommended", remove the following rules: "declaration-block-no-shorthand-property-overrides", "declaration-block-single-line-max-declarations", "media-feature-name-no-vendor-prefix", "number-max-precision", "property-no-vendor-prefix", "selector-no-vendor-prefix"